### PR TITLE
fix code to run under win32

### DIFF
--- a/src/filemq.c
+++ b/src/filemq.c
@@ -56,7 +56,7 @@ int main (int argc, char *argv [])
     fmq_client_subscribe (client, "/");
     
     while (!zctx_interrupted)
-        sleep (1);
+        zclock_sleep (1000);
     puts ("interrupted");
 
     fmq_server_destroy (&server);

--- a/src/fmq_client.c
+++ b/src/fmq_client.c
@@ -847,7 +847,7 @@ fmq_client_test (bool verbose)
     assert (self);
     fmq_client_configure (self, "client_test.cfg");
     fmq_client_connect (self, "tcp://localhost:6001");
-    sleep (1);                                        
+    zclock_sleep (1000);
     fmq_client_destroy (&self);
 
     printf ("OK\n");

--- a/src/fmq_dir.c
+++ b/src/fmq_dir.c
@@ -118,17 +118,18 @@ fmq_dir_new (const char *path, const char *parent)
         self->path [strlen (self->path) - 1] = 0;
     
     //  Win32 wants a wildcard at the end of the path
-    char wildcard = malloc (strlen (self->path + 2));
-    sprintf (wildcard, "%s//", self->path);
+    char *wildcard = malloc (strlen (self->path) + 3);
+    sprintf (wildcard, "%s/*", self->path);
     WIN32_FIND_DATA entry;
     HANDLE handle = FindFirstFile (wildcard, &entry);
     free (wildcard);
     
     if (handle != INVALID_HANDLE_VALUE) {
         //  We have read an entry, so return those values
-        win_populate_entry (self, entry);
+        s_win32_populate_entry (self, &entry);
         while (FindNextFile (handle, &entry))
             s_win32_populate_entry (self, &entry);
+        FindClose (handle);
     }
 #else
     //  Remove any trailing slash

--- a/src/fmq_selftest.c
+++ b/src/fmq_selftest.c
@@ -61,7 +61,7 @@ int main (int argc, char *argv [])
         //  We do this last
         fmq_server_bind (server, "tcp://*:5670");
         while (!zctx_interrupted)
-            sleep (1);
+            zclock_sleep (1000);
         fmq_server_destroy (&server);
     }
     else


### PR DESCRIPTION
issues:
fmq_hash_update() asserts non-alignment failure on win32/x86 as sizeof(fmq_chunk_t) is 12 bytes.

other than that, fmq_selftest runs without assertions.
