### PR TITLE
align fmq_chunk_t to 64-bits

### DIFF
--- a/src/fmq_chunk.c
+++ b/src/fmq_chunk.c
@@ -31,7 +31,7 @@ struct _fmq_chunk_t {
     size_t size;                //  Current size of data part
     size_t max_size;            //  Maximum allocated size
     byte  *data;                //  Data part follows here
-};
+} __attribute__ ((aligned (8)));
 
 
 //  --------------------------------------------------------------------------


### PR DESCRIPTION
problem: On 32-bit machines, fmq_chunk_t is not  8-byte aligned which causes fmq_hash_update() to assert.
