### PR TITLE
fix for osx10.7 deprecated function in openssl

### DIFF
--- a/src/fmq_hash.c
+++ b/src/fmq_hash.c
@@ -23,7 +23,13 @@
 */
 
 #include <czmq.h>
-#include <openssl/sha.h>
+#if defined(__APPLE__)
+#  define COMMON_DIGEST_FOR_OPENSSL
+#  include <CommonCrypto/CommonDigest.h>
+#  define SHA1 CC_SHA1
+#else
+#  include <openssl/sha.h>
+#endif
 #include "../include/fmq.h"
 
 


### PR DESCRIPTION
Building fmq on 10.7/clang, i get few deprecated function in use. This is specific to osx and i don't know why those openssl functions are deprecated on 10.7. 

fmq_hash.c:47:5: error: 'SHA1_Init' is deprecated [-Werror,-Wdeprecated-declarations]
SHA1_Init (&self->context);
^
fmq_hash.c:74:5: error: 'SHA1_Update' is deprecated [-Werror,-Wdeprecated-declarations]
SHA1_Update (&self->context, buffer, length);
^
fmq_hash.c:85:9: error: 'SHA1_Final' is deprecated [-Werror,-Wdeprecated-declarations]
SHA1_Final (self->hash, &self->context);

standalone patch: https://gist.github.com/4466305
