### PR TITLE
Change --with-czmq to --with-libczmq

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -89,7 +89,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <zmq.h>],
 
 # libczmq integration
 AC_ARG_WITH([libczmq],
-            [AS_HELP_STRING([--with-czmq],
+            [AS_HELP_STRING([--with-libczmq],
                             [Specify libczmq prefix])],
             [fmq_search_libczmq="yes"],
             [])
@@ -110,7 +110,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <czmq.h>],
                                 [zctx_new ();])
                ],
                [AC_MSG_RESULT([yes])],
-               [AC_MSG_ERROR([no. Please specify libczmq installation prefix using --with-czmq])])
+               [AC_MSG_ERROR([no. Please specify libczmq installation prefix using --with-libczmq])])
 
 # Other libraries
 AC_CHECK_LIB(crypto, SHA1_Init, ,[AC_MSG_ERROR([cannot link with -lcrypto, install libssl-dev.])])


### PR DESCRIPTION
The help message from ./configure --help says to use --with-czmq, but
this didn't work. Upon checking the generated configure script, it
looked like it was expecting --with-libczmq, so I changed the help
message in configure.in accordingly
