### PR TITLE
Added ldconfig after dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,35 @@
+#   FileMQ 
+
 language: c
 
 #   Build required ZeroMQ projects first
 before_script:
-#
+
 #   libzmq
 - git clone git://github.com/zeromq/libzmq.git
 - cd libzmq
 - ./autogen.sh
 - ./configure && make check
 - sudo make install
+- sudo ldconfig
 - cd ..
-#
+
+#   libsodium
+- git clone git://github.com/jedisct1/libsodium.git
+- cd libsodium
+- ./autogen.sh
+- ./configure && make check
+- sudo make install
+- sudo ldconfig
+- cd ..
+
 #   CZMQ
 - git clone git://github.com/zeromq/czmq.git
 - cd czmq
 - ./autogen.sh
 - ./configure && make check
 - sudo make install
+- sudo ldconfig
 - cd ..
 
 #   Build and check libfmq


### PR DESCRIPTION
For some bizarre reason without this, Travis pulls an old libzmq out of thin air and things break. I also added support for libsodium.
