### PR TITLE
Initialize login and password to avoid warning or worse.

### DIFF
--- a/src/fmq_server.c
+++ b/src/fmq_server.c
@@ -755,7 +755,7 @@ static void
 try_security_mechanism (server_t *self, client_t *client)
 {
     client->next_event = foe_event;                                                          
-    char *login, *password;                                                                  
+    char *login = NULL, *password = NULL;
     if (streq (fmq_msg_mechanism (client->request), "PLAIN")                                 
     &&  fmq_sasl_plain_decode (fmq_msg_response (client->request), &login, &password) == 0) {
         zconfig_t *account = zconfig_locate (self->config, "security/plain/account");        


### PR DESCRIPTION
Initialize char\* login and password in try_security_mechanism() to avoid
error when building with current llvm clang compiler.

clang bails with "error: variable 'login' is used uninitialized whenever
'&&' condition is false [-Werror,-Wsometimes-uninitialized]", and then a
similar message for 'password'.

If the streq() condition is false, login and password may be pointed
who-knows-where when free()'d later.
