### PR TITLE
configure.ac: drop -Werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -366,7 +366,7 @@ AC_C_BIGENDIAN
 
 # These options are GNU compiler specific.
 if test "x$GCC" = "xyes"; then
-    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
+    CPPFLAGS="-pedantic -Wall -Wc++-compat ${CPPFLAGS}"
 fi
 
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")


### PR DESCRIPTION
Drop `-Werror` to avoid the following build failure with `-DNDEBUG`:

```
src/filemq_client.c:7:6: error: variable 'rc' set but not used [-Werror=unused-but-set-variable]
    7 |  int rc;
      |      ^~
```

Fixes:
 - http://autobuild.buildroot.org/results/cf4c45ed7ae2c5090ac6ba967497e0d42d5c5224

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>