### PR TITLE
Problem: CMakeLists.txt does not properly enable drafts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,28 @@ set(
 ########################################################################
 # options
 ########################################################################
-if (EXISTS ".git")
+if (NOT CMAKE_BUILD_TYPE)
+    if (EXISTS "${SOURCE_DIR}/.git")
+        set (CMAKE_BUILD_TYPE Debug)
+    else ()
+        # http://xit0.org/2013/04/cmake-use-git-branch-and-commit-details-in-project/
+        # http://stackoverflow.com/questions/6797395/cmake-execute-process-always-fails-with-no-such-file-or-directory-when-i-cal
+        execute_process(
+                COMMAND git rev-parse --show-toplevel
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                RESULT_VARIABLE git_result
+                OUTPUT_VARIABLE git_root
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        message(STATUS "git workspace root [${git_result}]: ${git_root}")
+        if ( "${git_result}" STREQUAL "0" )
+            set (CMAKE_BUILD_TYPE Debug)
+        else ()
+            set (CMAKE_BUILD_TYPE Release)
+        endif ()
+    endif ()
+endif ()
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
     OPTION (WITH_DRAFTS "Build and install draft classes and methods" ON)
 else ()
     OPTION (WITH_DRAFTS "Build and install draft classes and methods" OFF)


### PR DESCRIPTION
Solution:  Use the CMake technique employed in zeromq/malamute for detection when to use drafts.

This pull request implements a change to allow CLion to properly detect drafts when opening the project as a CMake project. This is achieved by using the same technique employed by the zeromq's 'malamute' project  https://github.com/zeromq/malamute/blob/master/CMakeLists.txt#L32-L60

When opening this project in CLion as a CMake project, it fails to detect drafts despite the presence of a .git directory. Since this project relies on drafts and has no sources without them, it's essential that drafts are detected correctly to ensure proper functionality.